### PR TITLE
Removed version cap settings for railties and thor

### DIFF
--- a/facebox-rails.gemspec
+++ b/facebox-rails.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
 
-  s.add_dependency "railties", ">= 3.0", "< 5.0"
-  s.add_dependency "thor",     ">= 0.14", "< 2.0"
+  s.add_dependency "railties", ">= 3.0"
+  s.add_dependency "thor",     ">= 0.14"
 end


### PR DESCRIPTION
Because it seems to work on railties 5.0 or later.